### PR TITLE
Validated At Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ return MailboxLayer::check('example@domain.com');
 | disposable  | Whether or not the requested email is disposable. Example: 'hello@mailinator.com'.                    |
 | free        | Whether or not the requested email is a free email address.                                           |
 | score       | A score between 0 and 1 reflecting the quality and deliverability of the requested email address.     |
+| validatedAt | A ` Carbon ` object containing the date and time that the original validation API request was made.   |
 
 ### Caching
 #### Caching Validation Results

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@
     
 ## Overview
 Laravel Mailbox Layer is a lightweight wrapper Laravel package that can be used for validating email addresses via the
-[Mailbox Layer API](https://mailboxlayer.com/). The package supports caching and contains a validation rule so that you can start
-validating email addresses instantly.
+[Mailbox Layer API](https://mailboxlayer.com/). The package supports caching so that you can start validating email addresses instantly.
 
 ## Installation
 
@@ -137,6 +136,9 @@ you try to validate the email again, due to the fact that the results will be fe
 As an example, if you were importing a CSV containing email addresses, you might want to validate each of the addresses. However, if the
 CSV contains some duplicated email addresses, it could lead to unnecessary API calls being made. So, by using the caching, each unique
 address would only be fetched once from the API. To do this, you can use the ` shouldCache() ` method.
+
+Using caching is recommended as it reduces the chances of you reaching the monthly request limits or rate limits that are
+used by Mailbox Layer. Read more about the [API limits here](https://mailboxlayer.com/documentation#rate_limits).
 
 The example below shows how to cache the validation results:
 

--- a/src/Classes/ValidationResult.php
+++ b/src/Classes/ValidationResult.php
@@ -112,7 +112,10 @@ class ValidationResult
 
     /**
      * Build a new ValidationObject from the API response
-     * data, set the properties and then return it.
+     * data, set the properties and then return it. If
+     * we are making the object from an API response
+     * rather than from a cached result, we will
+     * also set the validatedAt date.
      *
      * @param  array  $response
      * @return static
@@ -126,7 +129,7 @@ class ValidationResult
             $validationResult->{$objectFieldName} = $value;
         }
 
-        if (! $validationResult->validatedAt) {
+        if (empty($validationResult->validatedAt)) {
             $validationResult->validatedAt = now();
         }
 

--- a/src/Classes/ValidationResult.php
+++ b/src/Classes/ValidationResult.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\MailboxLayer\Classes;
 
+use Carbon\Carbon;
 use Illuminate\Support\Str;
 
 class ValidationResult
@@ -102,6 +103,14 @@ class ValidationResult
     public $score;
 
     /**
+     * The date amd time when the validation check was run
+     *  via API.
+     *
+     * @var Carbon
+     */
+    public $validatedAt;
+
+    /**
      * Build a new ValidationObject from the API response
      * data, set the properties and then return it.
      *
@@ -115,6 +124,10 @@ class ValidationResult
         foreach ($response as $fieldName => $value) {
             $objectFieldName = Str::camel((string) $fieldName);
             $validationResult->{$objectFieldName} = $value;
+        }
+
+        if (! $validationResult->validatedAt) {
+            $validationResult->validatedAt = now();
         }
 
         return $validationResult;

--- a/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
+++ b/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
@@ -4,6 +4,7 @@ namespace AshAllenDesign\MailboxLayer\Tests\Unit\Classes\MailboxLayer;
 
 use AshAllenDesign\MailboxLayer\Classes\MailboxLayer;
 use AshAllenDesign\MailboxLayer\Tests\Unit\TestCase;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -13,6 +14,8 @@ class CheckManyTest extends TestCase
     /** @test */
     public function many_emails_can_be_validated_via_the_api()
     {
+        Carbon::setTestNow(now());
+
         Cache::shouldReceive('get')
             ->once()
             ->withArgs(['mailboxlayer_result_mail@ashallendesign.co.uk'])
@@ -24,7 +27,7 @@ class CheckManyTest extends TestCase
             ->andReturnNull();
 
         Http::fake([
-            'https://apilayer.net/api/check?access_key=123&email=mail%40ashallendesign.co.uk&smtp=1' => Http::response([
+            'https://apilayer.net/api/check?access_key=123&email=mail%40ashallendesign.co.uk&smtp=1'     => Http::response([
                 'email'       => 'mail@ashallendesign.co.uk',
                 'didYouMean'  => '',
                 'user'        => 'mail',
@@ -69,6 +72,7 @@ class CheckManyTest extends TestCase
         $this->assertEquals(false, $result[0]->disposable);
         $this->assertEquals(false, $result[0]->free);
         $this->assertEquals(0.8, $result[0]->score);
+        $this->assertEquals(now(), $result[0]->validatedAt);
 
         $this->assertEquals('support1@ashallendesign.co.uk', $result[1]->email);
         $this->assertEquals('support@ashallendesign.co.uk', $result[1]->didYouMean);
@@ -80,6 +84,7 @@ class CheckManyTest extends TestCase
         $this->assertEquals(true, $result[1]->disposable);
         $this->assertEquals(true, $result[1]->free);
         $this->assertEquals(0.7, $result[1]->score);
+        $this->assertEquals(now(), $result[1]->validatedAt);
     }
 
     /** @test */
@@ -90,18 +95,19 @@ class CheckManyTest extends TestCase
             ->once()
             ->withArgs(['mailboxlayer_result_mail@ashallendesign.co.uk'])
             ->andReturn([
-                'email'       => 'mail@ashallendesign.co.uk',
-                'didYouMean'  => '',
-                'user'        => 'mail',
-                'domain'      => 'ashallendesign.co.uk',
-                'formatValid' => true,
-                'mxFound'     => true,
-                'smtpCheck'   => true,
-                'catchAll'    => false,
-                'role'        => true,
-                'disposable'  => false,
-                'free'        => false,
-                'score'       => 0.8,
+                'email'        => 'mail@ashallendesign.co.uk',
+                'didYouMean'   => '',
+                'user'         => 'mail',
+                'domain'       => 'ashallendesign.co.uk',
+                'formatValid'  => true,
+                'mxFound'      => true,
+                'smtpCheck'    => true,
+                'catchAll'     => false,
+                'role'         => true,
+                'disposable'   => false,
+                'free'         => false,
+                'score'        => 0.8,
+                'validatedAt' => now()->subDays(5)->startOfDay()
             ]);
 
         // Set a cached value that we can get.
@@ -109,18 +115,19 @@ class CheckManyTest extends TestCase
             ->once()
             ->withArgs(['mailboxlayer_result_support1@ashallendesign.co.uk'])
             ->andReturn([
-                'email'       => 'support1@ashallendesign.co.uk',
-                'didYouMean'  => 'support@ashallendesign.co.uk',
-                'user'        => 'support1',
-                'domain'      => 'ashallendesign.co.uk',
-                'formatValid' => false,
-                'mxFound'     => false,
-                'smtpCheck'   => false,
-                'catchAll'    => true,
-                'role'        => false,
-                'disposable'  => true,
-                'free'        => true,
-                'score'       => 0.7,
+                'email'        => 'support1@ashallendesign.co.uk',
+                'didYouMean'   => 'support@ashallendesign.co.uk',
+                'user'         => 'support1',
+                'domain'       => 'ashallendesign.co.uk',
+                'formatValid'  => false,
+                'mxFound'      => false,
+                'smtpCheck'    => false,
+                'catchAll'     => true,
+                'role'         => false,
+                'disposable'   => true,
+                'free'         => true,
+                'score'        => 0.7,
+                'validatedAt' => now()->subYear()->startOfDay()
             ]);
 
         // Assert that the HTTP client is never called.
@@ -141,6 +148,7 @@ class CheckManyTest extends TestCase
         $this->assertEquals(false, $result[0]->disposable);
         $this->assertEquals(false, $result[0]->free);
         $this->assertEquals(0.8, $result[0]->score);
+        $this->assertEquals(now()->subDays(5)->startOfDay(), $result[0]->validatedAt);
 
         $this->assertEquals('support1@ashallendesign.co.uk', $result[1]->email);
         $this->assertEquals('support@ashallendesign.co.uk', $result[1]->didYouMean);
@@ -152,5 +160,6 @@ class CheckManyTest extends TestCase
         $this->assertEquals(true, $result[1]->disposable);
         $this->assertEquals(true, $result[1]->free);
         $this->assertEquals(0.7, $result[1]->score);
+        $this->assertEquals(now()->subYear()->startOfDay(), $result[1]->validatedAt);
     }
 }

--- a/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
+++ b/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
@@ -107,7 +107,7 @@ class CheckManyTest extends TestCase
                 'disposable'   => false,
                 'free'         => false,
                 'score'        => 0.8,
-                'validatedAt' => now()->subDays(5)->startOfDay()
+                'validatedAt' => now()->subDays(5)->startOfDay(),
             ]);
 
         // Set a cached value that we can get.
@@ -127,7 +127,7 @@ class CheckManyTest extends TestCase
                 'disposable'   => true,
                 'free'         => true,
                 'score'        => 0.7,
-                'validatedAt' => now()->subYear()->startOfDay()
+                'validatedAt' => now()->subYear()->startOfDay(),
             ]);
 
         // Assert that the HTTP client is never called.

--- a/tests/Unit/Classes/MailboxLayer/CheckTest.php
+++ b/tests/Unit/Classes/MailboxLayer/CheckTest.php
@@ -7,12 +7,20 @@ use AshAllenDesign\MailboxLayer\Classes\ValidationResult;
 use AshAllenDesign\MailboxLayer\Exceptions\MailboxLayerException;
 use AshAllenDesign\MailboxLayer\Facades\MailboxLayer as MailboxLayerFacade;
 use AshAllenDesign\MailboxLayer\Tests\Unit\TestCase;
+use Carbon\Carbon;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class CheckTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(now());
+    }
+
     /** @test */
     public function result_is_returned_from_cache_if_fresh_is_set_to_false_and_it_exists_in_the_cache()
     {
@@ -98,7 +106,7 @@ class CheckTest extends TestCase
         Cache::shouldReceive('forever')
             ->withArgs([
                 'mailboxlayer_result_mail@ashallendesign.co.uk',
-                $this->responseStructure(),
+                array_merge($this->responseStructure(), ['validatedAt' => now()]),
             ])
             ->once()
             ->andReturnTrue();
@@ -238,5 +246,6 @@ class CheckTest extends TestCase
         $this->assertEquals(false, $result->disposable);
         $this->assertEquals(false, $result->free);
         $this->assertEquals(0.8, $result->score);
+        $this->assertEquals(now(), $result->validatedAt);
     }
 }

--- a/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
+++ b/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
@@ -74,5 +74,4 @@ class MakeFromResponseTest extends TestCase
         $this->assertEquals(0.8, $newObject->score);
         $this->assertEquals(now(), $newObject->validatedAt);
     }
-
 }

--- a/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
+++ b/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
@@ -24,7 +24,7 @@ class MakeFromResponseTest extends TestCase
             'disposable'   => false,
             'free'         => false,
             'score'        => 0.8,
-            'validated_at' => now()
+            'validated_at' => now(),
         ];
 
         $newObject = ValidationResult::makeFromResponse($responseData);

--- a/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
+++ b/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
@@ -4,12 +4,49 @@ namespace AshAllenDesign\MailboxLayer\Tests\Unit\Classes\ValidationResult;
 
 use AshAllenDesign\MailboxLayer\Classes\ValidationResult;
 use AshAllenDesign\MailboxLayer\Tests\Unit\TestCase;
+use Carbon\Carbon;
 
 class MakeFromResponseTest extends TestCase
 {
     /** @test */
-    public function new_object_is_returned_with_correct_fields_set()
+    public function new_object_is_returned_with_correct_fields_set_and_the_validatedAt_date_is_already_set()
     {
+        Carbon::setTestNow(now());
+
+        $responseData = [
+            'email'        => 'mai1l@ashallendesign.co.uk',
+            'did_you_mean' => 'mail@ashallendesign.co.uk',
+            'user'         => 'mai1l',
+            'domain'       => 'ashallendesign.co.uk',
+            'format_valid' => true,
+            'smtp_check'   => true,
+            'role'         => true,
+            'disposable'   => false,
+            'free'         => false,
+            'score'        => 0.8,
+            'validated_at' => now()
+        ];
+
+        $newObject = ValidationResult::makeFromResponse($responseData);
+
+        $this->assertEquals('mai1l@ashallendesign.co.uk', $newObject->email);
+        $this->assertEquals('mail@ashallendesign.co.uk', $newObject->didYouMean);
+        $this->assertEquals('mai1l', $newObject->user);
+        $this->assertEquals('ashallendesign.co.uk', $newObject->domain);
+        $this->assertEquals(true, $newObject->formatValid);
+        $this->assertEquals(true, $newObject->smtpCheck);
+        $this->assertEquals(true, $newObject->role);
+        $this->assertEquals(false, $newObject->disposable);
+        $this->assertEquals(false, $newObject->free);
+        $this->assertEquals(0.8, $newObject->score);
+        $this->assertEquals(now(), $newObject->validatedAt);
+    }
+
+    /** @test */
+    public function new_object_is_returned_with_correct_fields_set_and_the_validatedAt_date_is_not_already_set()
+    {
+        Carbon::setTestNow(now());
+
         $responseData = [
             'email'        => 'mai1l@ashallendesign.co.uk',
             'did_you_mean' => 'mail@ashallendesign.co.uk',
@@ -35,5 +72,7 @@ class MakeFromResponseTest extends TestCase
         $this->assertEquals(false, $newObject->disposable);
         $this->assertEquals(false, $newObject->free);
         $this->assertEquals(0.8, $newObject->score);
+        $this->assertEquals(now(), $newObject->validatedAt);
     }
+
 }


### PR DESCRIPTION
This PR adds a `validatedAt` field to the `ValidationResult` object so that we can see when the original validation was carried out.

Issue: #9 