### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
+++ b/tests/Unit/Classes/MailboxLayer/CheckManyTest.php
@@ -60,30 +60,30 @@ class CheckManyTest extends TestCase
         $mailboxLayer = new MailboxLayer(123);
 
         $result = $mailboxLayer->checkMany(['mail@ashallendesign.co.uk', 'support1@ashallendesign.co.uk']);
-        $this->assertEquals(Collection::class, get_class($result));
+        $this->assertInstanceOf(Collection::class, $result);
 
-        $this->assertEquals('mail@ashallendesign.co.uk', $result[0]->email);
-        $this->assertEquals('', $result[0]->didYouMean);
-        $this->assertEquals('mail', $result[0]->user);
-        $this->assertEquals('ashallendesign.co.uk', $result[0]->domain);
-        $this->assertEquals(true, $result[0]->formatValid);
-        $this->assertEquals(true, $result[0]->smtpCheck);
-        $this->assertEquals(true, $result[0]->role);
-        $this->assertEquals(false, $result[0]->disposable);
-        $this->assertEquals(false, $result[0]->free);
-        $this->assertEquals(0.8, $result[0]->score);
+        $this->assertSame('mail@ashallendesign.co.uk', $result[0]->email);
+        $this->assertSame('', $result[0]->didYouMean);
+        $this->assertSame('mail', $result[0]->user);
+        $this->assertSame('ashallendesign.co.uk', $result[0]->domain);
+        $this->assertTrue($result[0]->formatValid);
+        $this->assertTrue($result[0]->smtpCheck);
+        $this->assertTrue($result[0]->role);
+        $this->assertFalse($result[0]->disposable);
+        $this->assertFalse($result[0]->free);
+        $this->assertSame(0.8, $result[0]->score);
         $this->assertEquals(now(), $result[0]->validatedAt);
 
-        $this->assertEquals('support1@ashallendesign.co.uk', $result[1]->email);
-        $this->assertEquals('support@ashallendesign.co.uk', $result[1]->didYouMean);
-        $this->assertEquals('support1', $result[1]->user);
-        $this->assertEquals('ashallendesign.co.uk', $result[1]->domain);
-        $this->assertEquals(false, $result[1]->formatValid);
-        $this->assertEquals(false, $result[1]->smtpCheck);
-        $this->assertEquals(false, $result[1]->role);
-        $this->assertEquals(true, $result[1]->disposable);
-        $this->assertEquals(true, $result[1]->free);
-        $this->assertEquals(0.7, $result[1]->score);
+        $this->assertSame('support1@ashallendesign.co.uk', $result[1]->email);
+        $this->assertSame('support@ashallendesign.co.uk', $result[1]->didYouMean);
+        $this->assertSame('support1', $result[1]->user);
+        $this->assertSame('ashallendesign.co.uk', $result[1]->domain);
+        $this->assertFalse($result[1]->formatValid);
+        $this->assertFalse($result[1]->smtpCheck);
+        $this->assertFalse($result[1]->role);
+        $this->assertTrue($result[1]->disposable);
+        $this->assertTrue($result[1]->free);
+        $this->assertSame(0.7, $result[1]->score);
         $this->assertEquals(now(), $result[1]->validatedAt);
     }
 
@@ -136,30 +136,30 @@ class CheckManyTest extends TestCase
         $mailboxLayer = new MailboxLayer(123);
 
         $result = $mailboxLayer->checkMany(['mail@ashallendesign.co.uk', 'support1@ashallendesign.co.uk']);
-        $this->assertEquals(Collection::class, get_class($result));
+        $this->assertInstanceOf(Collection::class, $result);
 
-        $this->assertEquals('mail@ashallendesign.co.uk', $result[0]->email);
-        $this->assertEquals('', $result[0]->didYouMean);
-        $this->assertEquals('mail', $result[0]->user);
-        $this->assertEquals('ashallendesign.co.uk', $result[0]->domain);
-        $this->assertEquals(true, $result[0]->formatValid);
-        $this->assertEquals(true, $result[0]->smtpCheck);
-        $this->assertEquals(true, $result[0]->role);
-        $this->assertEquals(false, $result[0]->disposable);
-        $this->assertEquals(false, $result[0]->free);
-        $this->assertEquals(0.8, $result[0]->score);
+        $this->assertSame('mail@ashallendesign.co.uk', $result[0]->email);
+        $this->assertSame('', $result[0]->didYouMean);
+        $this->assertSame('mail', $result[0]->user);
+        $this->assertSame('ashallendesign.co.uk', $result[0]->domain);
+        $this->assertTrue($result[0]->formatValid);
+        $this->assertTrue($result[0]->smtpCheck);
+        $this->assertTrue($result[0]->role);
+        $this->assertFalse($result[0]->disposable);
+        $this->assertFalse($result[0]->free);
+        $this->assertSame(0.8, $result[0]->score);
         $this->assertEquals(now()->subDays(5)->startOfDay(), $result[0]->validatedAt);
 
-        $this->assertEquals('support1@ashallendesign.co.uk', $result[1]->email);
-        $this->assertEquals('support@ashallendesign.co.uk', $result[1]->didYouMean);
-        $this->assertEquals('support1', $result[1]->user);
-        $this->assertEquals('ashallendesign.co.uk', $result[1]->domain);
-        $this->assertEquals(false, $result[1]->formatValid);
-        $this->assertEquals(false, $result[1]->smtpCheck);
-        $this->assertEquals(false, $result[1]->role);
-        $this->assertEquals(true, $result[1]->disposable);
-        $this->assertEquals(true, $result[1]->free);
-        $this->assertEquals(0.7, $result[1]->score);
+        $this->assertSame('support1@ashallendesign.co.uk', $result[1]->email);
+        $this->assertSame('support@ashallendesign.co.uk', $result[1]->didYouMean);
+        $this->assertSame('support1', $result[1]->user);
+        $this->assertSame('ashallendesign.co.uk', $result[1]->domain);
+        $this->assertFalse($result[1]->formatValid);
+        $this->assertFalse($result[1]->smtpCheck);
+        $this->assertFalse($result[1]->role);
+        $this->assertTrue($result[1]->disposable);
+        $this->assertTrue($result[1]->free);
+        $this->assertSame(0.7, $result[1]->score);
         $this->assertEquals(now()->subYear()->startOfDay(), $result[1]->validatedAt);
     }
 }

--- a/tests/Unit/Classes/MailboxLayer/CheckTest.php
+++ b/tests/Unit/Classes/MailboxLayer/CheckTest.php
@@ -236,16 +236,16 @@ class CheckTest extends TestCase
 
     private function assertValidationResultIsCorrect(ValidationResult $result): void
     {
-        $this->assertEquals('mail@ashallendesign.co.uk', $result->email);
-        $this->assertEquals('', $result->didYouMean);
-        $this->assertEquals('mail', $result->user);
-        $this->assertEquals('ashallendesign.co.uk', $result->domain);
-        $this->assertEquals(true, $result->formatValid);
-        $this->assertEquals(true, $result->smtpCheck);
-        $this->assertEquals(true, $result->role);
-        $this->assertEquals(false, $result->disposable);
-        $this->assertEquals(false, $result->free);
-        $this->assertEquals(0.8, $result->score);
+        $this->assertSame('mail@ashallendesign.co.uk', $result->email);
+        $this->assertSame('', $result->didYouMean);
+        $this->assertSame('mail', $result->user);
+        $this->assertSame('ashallendesign.co.uk', $result->domain);
+        $this->assertTrue($result->formatValid);
+        $this->assertTrue($result->smtpCheck);
+        $this->assertTrue($result->role);
+        $this->assertFalse($result->disposable);
+        $this->assertFalse($result->free);
+        $this->assertSame(0.8, $result->score);
         $this->assertEquals(now(), $result->validatedAt);
     }
 }

--- a/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
+++ b/tests/Unit/Classes/ValidationResult/MakeFromResponseTest.php
@@ -29,16 +29,16 @@ class MakeFromResponseTest extends TestCase
 
         $newObject = ValidationResult::makeFromResponse($responseData);
 
-        $this->assertEquals('mai1l@ashallendesign.co.uk', $newObject->email);
-        $this->assertEquals('mail@ashallendesign.co.uk', $newObject->didYouMean);
-        $this->assertEquals('mai1l', $newObject->user);
-        $this->assertEquals('ashallendesign.co.uk', $newObject->domain);
-        $this->assertEquals(true, $newObject->formatValid);
-        $this->assertEquals(true, $newObject->smtpCheck);
-        $this->assertEquals(true, $newObject->role);
-        $this->assertEquals(false, $newObject->disposable);
-        $this->assertEquals(false, $newObject->free);
-        $this->assertEquals(0.8, $newObject->score);
+        $this->assertSame('mai1l@ashallendesign.co.uk', $newObject->email);
+        $this->assertSame('mail@ashallendesign.co.uk', $newObject->didYouMean);
+        $this->assertSame('mai1l', $newObject->user);
+        $this->assertSame('ashallendesign.co.uk', $newObject->domain);
+        $this->assertTrue($newObject->formatValid);
+        $this->assertTrue($newObject->smtpCheck);
+        $this->assertTrue($newObject->role);
+        $this->assertFalse($newObject->disposable);
+        $this->assertFalse($newObject->free);
+        $this->assertSame(0.8, $newObject->score);
         $this->assertEquals(now(), $newObject->validatedAt);
     }
 
@@ -62,16 +62,16 @@ class MakeFromResponseTest extends TestCase
 
         $newObject = ValidationResult::makeFromResponse($responseData);
 
-        $this->assertEquals('mai1l@ashallendesign.co.uk', $newObject->email);
-        $this->assertEquals('mail@ashallendesign.co.uk', $newObject->didYouMean);
-        $this->assertEquals('mai1l', $newObject->user);
-        $this->assertEquals('ashallendesign.co.uk', $newObject->domain);
-        $this->assertEquals(true, $newObject->formatValid);
-        $this->assertEquals(true, $newObject->smtpCheck);
-        $this->assertEquals(true, $newObject->role);
-        $this->assertEquals(false, $newObject->disposable);
-        $this->assertEquals(false, $newObject->free);
-        $this->assertEquals(0.8, $newObject->score);
+        $this->assertSame('mai1l@ashallendesign.co.uk', $newObject->email);
+        $this->assertSame('mail@ashallendesign.co.uk', $newObject->didYouMean);
+        $this->assertSame('mai1l', $newObject->user);
+        $this->assertSame('ashallendesign.co.uk', $newObject->domain);
+        $this->assertTrue($newObject->formatValid);
+        $this->assertTrue($newObject->smtpCheck);
+        $this->assertTrue($newObject->role);
+        $this->assertFalse($newObject->disposable);
+        $this->assertFalse($newObject->free);
+        $this->assertSame(0.8, $newObject->score);
         $this->assertEquals(now(), $newObject->validatedAt);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertTrue` to let expected be `true`.
- Using the `assertFalse` to let expected be `false`.
- Using the `assertSame` to let expected be same as `result`.
- Using the `assertInstanceOf` to let expected be specific class instance.